### PR TITLE
feat: Add `local-dns-detour` option to DNS configuration

### DIFF
--- a/frontend/src/constant/profile.ts
+++ b/frontend/src/constant/profile.ts
@@ -53,6 +53,7 @@ export const DnsConfigDefaults = (): ProfileType['dnsConfig'] => ({
   'resolver-dns': '223.5.5.5',
   'remote-resolver-dns': '8.8.8.8',
   'final-dns': FinalDnsType.Remote,
+  'local-dns-detour': t('outbound.direct'),
   'remote-dns-detour': t('outbound.select'),
   'fake-ip-range-v4': '198.18.0.1/16',
   'fake-ip-range-v6': 'fc00::/18',

--- a/frontend/src/lang/locale/en.ts
+++ b/frontend/src/lang/locale/en.ts
@@ -117,6 +117,7 @@ export default {
       'remote-dns': 'Remote DNS',
       'resolver-dns': 'Resolver DNS',
       'remote-resolver-dns': 'Remote Resolver DNS',
+      'local-dns-detour': 'Local DNS Detour',
       'remote-dns-detour': 'Remote DNS Detour',
       'final-dns': 'Fallback DNS',
       'fakeip-dns': 'Fake-IP DNS',

--- a/frontend/src/lang/locale/zh.ts
+++ b/frontend/src/lang/locale/zh.ts
@@ -117,6 +117,7 @@ export default {
       'remote-dns': '远程DNS',
       'resolver-dns': '本地解析DNS',
       'remote-resolver-dns': '远程解析DNS',
+      'local-dns-detour': '本地DNS出站',
       'remote-dns-detour': '远程DNS出站',
       'final-dns': '回退DNS',
       'fakeip-dns': 'Fake-IP DNS',

--- a/frontend/src/stores/profiles.ts
+++ b/frontend/src/stores/profiles.ts
@@ -63,6 +63,7 @@ export type ProfileType = {
     'resolver-dns': string
     'remote-resolver-dns': string
     'final-dns': FinalDnsType
+    'local-dns-detour': string
     'remote-dns-detour': string
     'fake-ip-range-v4': string
     'fake-ip-range-v6': string

--- a/frontend/src/utils/generator.ts
+++ b/frontend/src/utils/generator.ts
@@ -191,6 +191,8 @@ const generateDnsConfig = async (profile: ProfileType) => {
   const remote_resolver_dns = profile.dnsConfig['remote-resolver-dns']
   const local_dns = profile.dnsConfig['local-dns']
   const resolver_dns = profile.dnsConfig['resolver-dns']
+  const local_detour = profile.dnsConfig['local-dns-detour']
+  const local_detour_config = local_detour ? { detour: local_detour } : {}
   const remote_detour = profile.dnsConfig['remote-dns-detour']
   const remote_detour_config = remote_detour ? { detour: remote_detour } : {}
   const disable_cache = profile.dnsConfig['disable-cache']
@@ -213,12 +215,12 @@ const generateDnsConfig = async (profile: ProfileType) => {
         tag: 'local-dns',
         address: local_dns,
         address_resolver: 'resolver-dns',
-        detour: 'direct'
+        ...local_detour_config
       },
       {
         tag: 'resolver-dns',
         address: resolver_dns,
-        detour: 'direct'
+        ...local_detour_config
       },
       {
         tag: 'remote-resolver-dns',

--- a/frontend/src/views/ProfilesView/components/DnsConfig.vue
+++ b/frontend/src/views/ProfilesView/components/DnsConfig.vue
@@ -49,6 +49,10 @@ const proxyOptions = computed(() => [
       <Select v-model="fields['final-dns']" :options="FinalDnsOptions" />
     </div>
     <div class="form-item">
+      {{ t('kernel.dns.local-dns-detour') }}
+      <Select v-model="fields['local-dns-detour']" :options="proxyOptions" />
+    </div>
+    <div class="form-item">
       {{ t('kernel.dns.remote-dns-detour') }}
       <Select v-model="fields['remote-dns-detour']" :options="proxyOptions" />
     </div>


### PR DESCRIPTION
This change allows users to specify the detour of the local DNS resolver, considering that in some network environments, it may not be possible to directly connect to DNS servers.