### PR TITLE
fix: Set default value for `local_detour_config`

### DIFF
--- a/frontend/src/utils/generator.ts
+++ b/frontend/src/utils/generator.ts
@@ -192,7 +192,7 @@ const generateDnsConfig = async (profile: ProfileType) => {
   const local_dns = profile.dnsConfig['local-dns']
   const resolver_dns = profile.dnsConfig['resolver-dns']
   const local_detour = profile.dnsConfig['local-dns-detour']
-  const local_detour_config = local_detour ? { detour: local_detour } : {}
+  const local_detour_config = { detour: local_detour || 'direct' }
   const remote_detour = profile.dnsConfig['remote-dns-detour']
   const remote_detour_config = remote_detour ? { detour: remote_detour } : {}
   const disable_cache = profile.dnsConfig['disable-cache']


### PR DESCRIPTION
If local_detour is empty, set detour to `direct` instead of an empty object. This ensures that the local DNS detour configuration is always present, even if local_detour is not provided in the profile.