### PR TITLE
fix: legacy doh3 config

### DIFF
--- a/frontend/src/utils/generator.ts
+++ b/frontend/src/utils/generator.ts
@@ -329,8 +329,10 @@ const generateDns = (
 export const generateDnsServerURL = (dnsServer: IDNSServer) => {
   const { type, server_port, path, server, interface: _interface } = dnsServer
   let address = ''
-  if ([DnsServer.Https, DnsServer.H3].includes(type as any)) {
+  if (type == DnsServer.Https) {
     address = `https://${server}${server_port ? ':' + server_port : ''}${path ? path : ''}`
+  } else if (type == DnsServer.H3) {
+    address = `h3://${server}${server_port ? ':' + server_port : ''}${path ? path : ''}`
   } else if (type == DnsServer.Dhcp) {
     address = `dhcp://${_interface}`
   } else if (type == DnsServer.FakeIP) {


### PR DESCRIPTION
According to [singbox doc](https://sing-box.sagernet.org/configuration/dns/server/legacy/), the address for doh3 should start with "h3" rather than "https"