### PR TITLE
add new features

### DIFF
--- a/frontend/src/utils/helper.ts
+++ b/frontend/src/utils/helper.ts
@@ -462,6 +462,8 @@ export const addToRuleSet = async (
       rules[0].process_path = [
         ...new Set((rules[0].process_path || []).concat(payload.process_path)),
       ]
+    } else if (payload.domain_suffix) {
+      rules[0].domain_suffix = [...new Set((rules[0].domain_suffix || []).concat(payload.domain_suffix))]
     }
   })
   await Writefile(path, JSON.stringify({ version: 1, rules }, null, 2))

--- a/frontend/src/utils/helper.ts
+++ b/frontend/src/utils/helper.ts
@@ -463,7 +463,9 @@ export const addToRuleSet = async (
         ...new Set((rules[0].process_path || []).concat(payload.process_path)),
       ]
     } else if (payload.domain_suffix) {
-      rules[0].domain_suffix = [...new Set((rules[0].domain_suffix || []).concat(payload.domain_suffix))]
+      rules[0].domain_suffix = [
+        ...new Set((rules[0].domain_suffix || []).concat(payload.domain_suffix)),
+      ]
     }
   })
   await Writefile(path, JSON.stringify({ version: 1, rules }, null, 2))

--- a/frontend/src/views/HomeView/components/ConnectionsController.vue
+++ b/frontend/src/views/HomeView/components/ConnectionsController.vue
@@ -195,17 +195,14 @@ const menu: Menu[] = [
             value: { domain: record.metadata.host } as any,
             description: record.metadata.host,
           })
-
-          const domain_suffix = "." + record.metadata.host
-            .split('.').slice(1).join('.');
+          const domain_suffix = '.' + record.metadata.host.split('.').slice(1).join('.')
           options.push({
             label: t('kernel.rules.type.domain_suffix'),
             value: {
-              domain_suffix: domain_suffix
+              domain_suffix: domain_suffix,
             } as any,
             description: domain_suffix,
           })
-
         }
         if (record.metadata.destinationIP) {
           options.push({

--- a/frontend/src/views/HomeView/components/ConnectionsController.vue
+++ b/frontend/src/views/HomeView/components/ConnectionsController.vue
@@ -195,6 +195,17 @@ const menu: Menu[] = [
             value: { domain: record.metadata.host } as any,
             description: record.metadata.host,
           })
+
+          const domain_suffix = "." + record.metadata.host
+            .split('.').slice(1).join('.');
+          options.push({
+            label: t('kernel.rules.type.domain_suffix'),
+            value: {
+              domain_suffix: domain_suffix
+            } as any,
+            description: domain_suffix,
+          })
+
         }
         if (record.metadata.destinationIP) {
           options.push({


### PR DESCRIPTION
The reason for adding these codes is that I want to exclude some domain names more flexibly
I found that there has been no support for `domain_suffix`,`domain_keyword`,`domain_regx`. Currently, I have only added `domain_suffix`
If it is necessary to add the subsequent rule support, I will be very glad to help
see  sing-box [headless-rule](https://sing-box.sagernet.org/zh/configuration/rule-set/headless-rule/#_1)