### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/oschwald/geoip2-golang v1.11.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/shirou/gopsutil v3.21.11+incompatible
-	github.com/wailsapp/wails/v2 v2.10.1
+	github.com/wailsapp/wails/v2 v2.10.2
 	golang.org/x/sys v0.33.0
 	golang.org/x/text v0.26.0
 	gopkg.in/yaml.v3 v3.0.1


### PR DESCRIPTION
根目录下的 go.mod 文件，将 github.com/wailsapp/wails/v2 的版本从 2.10.1 更改为 2.10.2