### PR TITLE
feat: Relax isValidBase64 to accept non-standard base64 subscription payloads

### DIFF
--- a/frontend/src/utils/is.ts
+++ b/frontend/src/utils/is.ts
@@ -6,8 +6,20 @@ export const isValidBase64 = (str: string) => {
   if (str === '' || str.trim() === '') {
     return false
   }
+
+  // Accept URL-safe base64 and ignore line breaks/spaces in subscription responses.
+  const normalized = str
+    .trim()
+    .replace(/\s+/g, '')
+    .replace(/-/g, '+')
+    .replace(/_/g, '/')
+
+  const padding = (4 - (normalized.length % 4)) % 4
+  const padded = normalized + '='.repeat(padding)
+
   try {
-    return btoa(atob(str)) == str
+    atob(padded)
+    return true
   } catch {
     return false
   }


### PR DESCRIPTION
The original verification rule "btoa(atob(str)) == str" is too strict, and a more relox way is used in this PR to improve compatibility.