### PR TITLE
fix: keep rule action buttons visible for long rules

### DIFF
--- a/frontend/src/views/ProfilesView/components/DnsRulesConfig.vue
+++ b/frontend/src/views/ProfilesView/components/DnsRulesConfig.vue
@@ -188,13 +188,15 @@ const renderRule = (rule: IDNSRule) => {
           </Button>
         </Divider>
       </div>
-      <div v-else class="flex items-center py-2 gap-8">
-        <Switch v-model="rule.enable" border="square" size="small" />
-        <div class="font-bold">
+      <div v-else class="flex items-start py-2 gap-8">
+        <div class="shrink-0">
+          <Switch v-model="rule.enable" border="square" size="small" />
+        </div>
+        <div class="font-bold flex-1 rule-content">
           <span v-if="hasLost(rule)" class="warn cursor-pointer" @click="showLost"> [ ! ] </span>
           {{ renderRule(rule) }}
         </div>
-        <div class="ml-auto">
+        <div class="ml-auto shrink-0">
           <Button
             v-if="rule.type === RuleType.RuleSet && rule.payload && hasLost(rule)"
             size="small"
@@ -328,5 +330,10 @@ const renderRule = (rule: IDNSRule) => {
 <style lang="less" scoped>
 .warn {
   color: rgb(200, 193, 11);
+}
+
+.rule-content {
+  min-width: 0;
+  word-break: break-all;
 }
 </style>

--- a/frontend/src/views/ProfilesView/components/RouteRulesConfig.vue
+++ b/frontend/src/views/ProfilesView/components/RouteRulesConfig.vue
@@ -187,9 +187,11 @@ const renderRule = (rule: IRule) => {
           </Button>
         </Divider>
       </div>
-      <div v-else class="flex items-center py-2 gap-8">
-        <Switch v-model="rule.enable" border="square" size="small" />
-        <div class="font-bold">
+      <div v-else class="flex items-start py-2 gap-8">
+        <div class="shrink-0">
+          <Switch v-model="rule.enable" border="square" size="small" />
+        </div>
+        <div class="font-bold flex-1 rule-content">
           <span
             v-if="hasLost(rule)"
             class="cursor-pointer"
@@ -200,7 +202,7 @@ const renderRule = (rule: IRule) => {
           </span>
           {{ renderRule(rule) }}
         </div>
-        <div class="ml-auto">
+        <div class="ml-auto shrink-0">
           <Button
             v-if="rule.type === RuleType.RuleSet && rule.payload && hasLost(rule)"
             type="text"
@@ -341,3 +343,10 @@ const renderRule = (rule: IRule) => {
     </template>
   </Modal>
 </template>
+
+<style lang="less" scoped>
+.rule-content {
+  min-width: 0;
+  word-break: break-all;
+}
+</style>


### PR DESCRIPTION
Allow route and DNS rule text to wrap in the config list so edit/delete actions stay visible when rule content is long.
<img width="1085" height="159" alt="image" src="https://github.com/user-attachments/assets/f246930f-b09c-461b-9f9f-005f477f8fd1" />

