### PR TITLE
feat(rulesets): improve hub search with case-insensitive and multi-token matching

### DIFF
--- a/frontend/src/views/RulesetsView/components/RulesetHub.vue
+++ b/frontend/src/views/RulesetsView/components/RulesetHub.vue
@@ -26,8 +26,15 @@ const handleCancel = inject('cancel') as any
 watch(keywords, () => (currentPage.value = 1))
 
 const filteredList = computed(() => {
-  if (!keywords.value) return rulesetsStore.rulesetHub.list
-  return rulesetsStore.rulesetHub.list.filter((ruleset) => ruleset.name.includes(keywords.value))
+  const tokens = keywords.value.trim().split(/\s+/).filter(Boolean)
+  if (tokens.length === 0) return rulesetsStore.rulesetHub.list
+  const lowered = tokens.map((t) => t.toLocaleLowerCase())
+  return rulesetsStore.rulesetHub.list.filter((ruleset) => {
+    const fields = [ruleset.name, ruleset.type, ruleset.description].map((f) =>
+      f?.toLocaleLowerCase(),
+    )
+    return lowered.every((token) => fields.some((f) => f?.includes(token)))
+  })
 })
 
 const currentList = computed(() => {


### PR DESCRIPTION
## Problem

Ruleset Hub (规则集中心) search in RulesetHub.vue is case-sensitive, matches only the name field, and treats the whole input as a single substring (no combination search). This is inconsistent with ConnectionsController.vue, which already does case-insensitive matching.

## Change

Rewrite the filteredList filter (~9 lines, no UI change):

- Case-insensitive via bidirectional toLocaleLowerCase() (matches ConnectionsController)
- Trim input; empty/whitespace-only returns all
- Match across name / type / description
- Whitespace-separated multi-token AND search

| Input | Before | After |
|---|---|---|
| Apple | name exact-case only | any field containing apple |
| geoip | no results | all type=geoip entries |
| Apple geosite | 0 results | entries with type=geosite AND apple in name/desc |
|   apple  | 0 results | matches apple |
